### PR TITLE
fix: sort formatting on hero search page

### DIFF
--- a/components/gallery/HeroGallery.tsx
+++ b/components/gallery/HeroGallery.tsx
@@ -110,6 +110,7 @@ export function HeroGallery({ heroMap }: { heroMap: HeroMap }) {
           <Select
             value={sort.value}
             onChange={(sortValue) => handleSortChange(sortValue)}
+            className="mt-2"
           >
             {SORTS.map((sort) => (
               <MenuItem key={sort.value} value={sort.value}>


### PR DESCRIPTION
Just a simple formatting to leave space between the word sort and the box below it.

![image](https://github.com/RedWrath5/wikigrisser-next/assets/34580058/428684af-2a7a-4ca7-8c1c-2c1eae19d77e)


![image](https://github.com/RedWrath5/wikigrisser-next/assets/34580058/e78b2295-1231-4b8c-94ac-b18b0930926a)
